### PR TITLE
fix failing tests and refactor for more readibility

### DIFF
--- a/plantuml-generator-util/src/test/java/de/elnarion/util/plantuml/generator/PlantUMLClassDiagramGeneratorTest.java
+++ b/plantuml-generator-util/src/test/java/de/elnarion/util/plantuml/generator/PlantUMLClassDiagramGeneratorTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertNotNull;
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -23,6 +24,8 @@ import de.elnarion.util.plantuml.generator.config.PlantUMLConfigBuilder;
  */
 public class PlantUMLClassDiagramGeneratorTest {
 
+	private ClassLoader classLoader = this.getClass().getClassLoader();
+
 	/**
 	 * Test generate diagram with a normal test case with different linked classes
 	 * and compares the result with the text of the file 0001_general_diagram.txt.
@@ -32,15 +35,15 @@ public class PlantUMLClassDiagramGeneratorTest {
 	 */
 	@Test
 	public void test0001GenerateDiagram() throws IOException, ClassNotFoundException {
-		List<String> scanpackages = new ArrayList<>();
-		scanpackages.add("de.elnarion.test.domain.t0001");
+		List<String> scanPackages = new ArrayList<>();
+		scanPackages.add("de.elnarion.test.domain.t0001");
 		List<String> hideClasses = new ArrayList<>();
 		hideClasses.add("de.elnarion.test.domain.ChildB");
-		PlantUMLClassDiagramGenerator generator = new PlantUMLClassDiagramGenerator(this.getClass().getClassLoader(),
-				scanpackages, null, hideClasses, false, false);
+		PlantUMLClassDiagramGenerator generator = new PlantUMLClassDiagramGenerator(classLoader,
+				scanPackages, null, hideClasses, false, false);
 		String result = generator.generateDiagramText();
 		String expectedDiagramText = IOUtils
-				.toString(this.getClass().getClassLoader().getResource("0001_general_diagram.txt"), "utf-8");
+				.toString(classLoader.getResource("0001_general_diagram.txt"), StandardCharsets.UTF_8);
 		assertNotNull(result);
 		assertNotNull(expectedDiagramText);
 		assertEquals(expectedDiagramText.replaceAll("\\s+", ""), result.replaceAll("\\s+", ""));
@@ -54,14 +57,14 @@ public class PlantUMLClassDiagramGeneratorTest {
 	 */
 	@Test
 	public void test0002ClassTypes() throws IOException, ClassNotFoundException {
-		List<String> scanpackages = new ArrayList<>();
-		scanpackages.add("de.elnarion.test.domain.t0002");
+		List<String> scanPackages = new ArrayList<>();
+		scanPackages.add("de.elnarion.test.domain.t0002");
 		List<String> hideClasses = new ArrayList<>();
-		PlantUMLClassDiagramGenerator generator = new PlantUMLClassDiagramGenerator(this.getClass().getClassLoader(),
-				scanpackages, null, hideClasses, false, false);
+		PlantUMLClassDiagramGenerator generator = new PlantUMLClassDiagramGenerator(classLoader,
+				scanPackages, null, hideClasses, false, false);
 		String result = generator.generateDiagramText();
 		String expectedDiagramText = IOUtils
-				.toString(this.getClass().getClassLoader().getResource("0002_class_types.txt"), "utf-8");
+				.toString(classLoader.getResource("0002_class_types.txt"), StandardCharsets.UTF_8);
 		assertNotNull(result);
 		assertNotNull(expectedDiagramText);
 		assertEquals(expectedDiagramText.replaceAll("\\s+", ""), result.replaceAll("\\s+", ""));
@@ -75,14 +78,14 @@ public class PlantUMLClassDiagramGeneratorTest {
 	 */
 	@Test
 	public void test0003ClassRelationships() throws IOException, ClassNotFoundException {
-		List<String> scanpackages = new ArrayList<>();
-		scanpackages.add("de.elnarion.test.domain.t0003");
+		List<String> scanPackages = new ArrayList<>();
+		scanPackages.add("de.elnarion.test.domain.t0003");
 		List<String> hideClasses = new ArrayList<>();
-		PlantUMLClassDiagramGenerator generator = new PlantUMLClassDiagramGenerator(this.getClass().getClassLoader(),
-				scanpackages, null, hideClasses, false, false);
+		PlantUMLClassDiagramGenerator generator = new PlantUMLClassDiagramGenerator(classLoader,
+				scanPackages, null, hideClasses, false, false);
 		String result = generator.generateDiagramText();
 		String expectedDiagramText = IOUtils
-				.toString(this.getClass().getClassLoader().getResource("0003_class_relationships.txt"), "utf-8");
+				.toString(classLoader.getResource("0003_class_relationships.txt"), StandardCharsets.UTF_8);
 		assertNotNull(result);
 		assertNotNull(expectedDiagramText);
 		assertEquals(expectedDiagramText.replaceAll("\\s+", ""), result.replaceAll("\\s+", ""));
@@ -96,14 +99,14 @@ public class PlantUMLClassDiagramGeneratorTest {
 	 */
 	@Test
 	public void test0004ClassFields() throws IOException, ClassNotFoundException {
-		List<String> scanpackages = new ArrayList<>();
-		scanpackages.add("de.elnarion.test.domain.t0004");
+		List<String> scanPackages = new ArrayList<>();
+		scanPackages.add("de.elnarion.test.domain.t0004");
 		List<String> hideClasses = new ArrayList<>();
-		PlantUMLClassDiagramGenerator generator = new PlantUMLClassDiagramGenerator(this.getClass().getClassLoader(),
-				scanpackages, null, hideClasses, false, false);
+		PlantUMLClassDiagramGenerator generator = new PlantUMLClassDiagramGenerator(classLoader,
+				scanPackages, null, hideClasses, false, false);
 		String result = generator.generateDiagramText();
 		String expectedDiagramText = IOUtils
-				.toString(this.getClass().getClassLoader().getResource("0004_class_fields.txt"), "utf-8");
+				.toString(classLoader.getResource("0004_class_fields.txt"), StandardCharsets.UTF_8);
 		assertNotNull(result);
 		assertNotNull(expectedDiagramText);
 		assertEquals(expectedDiagramText.replaceAll("\\s+", ""), result.replaceAll("\\s+", ""));
@@ -117,14 +120,14 @@ public class PlantUMLClassDiagramGeneratorTest {
 	 */
 	@Test
 	public void test0005ClassMethods() throws IOException, ClassNotFoundException {
-		List<String> scanpackages = new ArrayList<>();
-		scanpackages.add("de.elnarion.test.domain.t0005");
+		List<String> scanPackages = new ArrayList<>();
+		scanPackages.add("de.elnarion.test.domain.t0005");
 		List<String> hideClasses = new ArrayList<>();
-		PlantUMLClassDiagramGenerator generator = new PlantUMLClassDiagramGenerator(this.getClass().getClassLoader(),
-				scanpackages, null, hideClasses, false, false);
+		PlantUMLClassDiagramGenerator generator = new PlantUMLClassDiagramGenerator(classLoader,
+				scanPackages, null, hideClasses, false, false);
 		String result = generator.generateDiagramText();
 		String expectedDiagramText = IOUtils
-				.toString(this.getClass().getClassLoader().getResource("0005_class_methods.txt"), "utf-8");
+				.toString(classLoader.getResource("0005_class_methods.txt"), StandardCharsets.UTF_8);
 		assertNotNull(result);
 		assertNotNull(expectedDiagramText);
 		assertEquals(expectedDiagramText.replaceAll("\\s+", ""), result.replaceAll("\\s+", ""));
@@ -138,15 +141,15 @@ public class PlantUMLClassDiagramGeneratorTest {
 	 */
 	@Test
 	public void test0006DifferentPackages() throws IOException, ClassNotFoundException {
-		List<String> scanpackages = new ArrayList<>();
-		scanpackages.add("de.elnarion.test.domain.t0006.pck1");
-		scanpackages.add("de.elnarion.test.domain.t0006.pck2");
+		List<String> scanPackages = new ArrayList<>();
+		scanPackages.add("de.elnarion.test.domain.t0006.pck1");
+		scanPackages.add("de.elnarion.test.domain.t0006.pck2");
 		List<String> hideClasses = new ArrayList<>();
-		PlantUMLClassDiagramGenerator generator = new PlantUMLClassDiagramGenerator(this.getClass().getClassLoader(),
-				scanpackages, null, hideClasses, false, false);
+		PlantUMLClassDiagramGenerator generator = new PlantUMLClassDiagramGenerator(classLoader,
+				scanPackages, null, hideClasses, false, false);
 		String result = generator.generateDiagramText();
 		String expectedDiagramText = IOUtils
-				.toString(this.getClass().getClassLoader().getResource("0006_different_packages.txt"), "utf-8");
+				.toString(classLoader.getResource("0006_different_packages.txt"), StandardCharsets.UTF_8);
 		assertNotNull(result);
 		assertNotNull(expectedDiagramText);
 		assertEquals(expectedDiagramText.replaceAll("\\s+", ""), result.replaceAll("\\s+", ""));
@@ -160,16 +163,60 @@ public class PlantUMLClassDiagramGeneratorTest {
 	 */
 	@Test
 	public void test0007HideParameters() throws IOException, ClassNotFoundException {
-		List<String> scanpackages = new ArrayList<>();
-		scanpackages.add("de.elnarion.test.domain.t0007");
+		List<String> scanPackages = new ArrayList<>();
+		scanPackages.add("de.elnarion.test.domain.t0007");
 		List<String> hideClasses = new ArrayList<>();
 		hideClasses.add("de.elnarion.test.domain.t0007.ClassB");
 		hideClasses.add("de.elnarion.test.domain.t0007.ClassC");
-		PlantUMLClassDiagramGenerator generator = new PlantUMLClassDiagramGenerator(this.getClass().getClassLoader(),
-				scanpackages, null, hideClasses, true, true);
+		PlantUMLClassDiagramGenerator generator = new PlantUMLClassDiagramGenerator(classLoader,
+				scanPackages, null, hideClasses, true, true);
 		String result = generator.generateDiagramText();
 		String expectedDiagramText = IOUtils
-				.toString(this.getClass().getClassLoader().getResource("0007_hide_parameters.txt"), "utf-8");
+				.toString(classLoader.getResource("0007_hide_parameters.txt"), StandardCharsets.UTF_8);
+		assertNotNull(result);
+		assertNotNull(expectedDiagramText);
+		assertEquals(expectedDiagramText.replaceAll("\\s+", ""), result.replaceAll("\\s+", ""));
+	}
+
+	/**
+	 * Test custom classloader.
+	 *
+	 * @throws Exception the exception
+	 */
+	@Test
+	public void test0008Classloader() throws Exception {
+		String filename = "0008_classloader_test.txt";
+		String testClassPath = "file:///" + System.getProperty("user.dir") + "/src/test/classes/";
+		URL[] classesURLs = new URL[] { new URL(testClassPath) };
+		URLClassLoader customClassLoader = new URLClassLoader(classesURLs);
+		customClassLoader.loadClass("de.elnarion.maven.plugin.plantuml.generator.test.domain.ChildA");
+		List<String> scanPackages = new ArrayList<>();
+		scanPackages.add("de.elnarion.maven.plugin.plantuml.generator.test.domain");
+		List<String> hideClasses = new ArrayList<>();
+		PlantUMLClassDiagramGenerator generator = new PlantUMLClassDiagramGenerator(customClassLoader, scanPackages, null,
+				hideClasses, true, true);
+		String result = generator.generateDiagramText();
+		String expectedDiagramText = IOUtils.toString(classLoader.getResource(filename), StandardCharsets.UTF_8);
+		assertNotNull(result);
+		assertNotNull(expectedDiagramText);
+		assertEquals(expectedDiagramText.replaceAll("\\s+", ""), result.replaceAll("\\s+", ""));
+	}
+
+	/**
+	 * Test classes contained in a package in a jar.
+	 *
+	 * @throws Exception the exception
+	 */
+	@Test
+	public void test0009JarPackage() throws Exception {
+		String filename = "0009_jar_test.txt";
+		List<String> scanPackages = new ArrayList<>();
+		scanPackages.add("org.apache.commons.io.monitor");
+		List<String> hideClasses = new ArrayList<>();
+		PlantUMLClassDiagramGenerator generator = new PlantUMLClassDiagramGenerator(classLoader,
+				scanPackages, null, hideClasses, true, true);
+		String result = generator.generateDiagramText();
+		String expectedDiagramText = IOUtils.toString(classLoader.getResource(filename), StandardCharsets.UTF_8);
 		assertNotNull(result);
 		assertNotNull(expectedDiagramText);
 		assertEquals(expectedDiagramText.replaceAll("\\s+", ""), result.replaceAll("\\s+", ""));
@@ -183,41 +230,14 @@ public class PlantUMLClassDiagramGeneratorTest {
 	 */
 	@Test
 	public void test0010ParameterizedAggregationType() throws IOException, ClassNotFoundException {
-		List<String> scanpackages = new ArrayList<>();
-		scanpackages.add("de.elnarion.test.domain.t0010");
+		List<String> scanPackages = new ArrayList<>();
+		scanPackages.add("de.elnarion.test.domain.t0010");
 		List<String> hideClasses = new ArrayList<>();
-		PlantUMLClassDiagramGenerator generator = new PlantUMLClassDiagramGenerator(this.getClass().getClassLoader(),
-				scanpackages, null, hideClasses, true, true);
+		PlantUMLClassDiagramGenerator generator = new PlantUMLClassDiagramGenerator(classLoader,
+				scanPackages, null, hideClasses, true, true);
 		String result = generator.generateDiagramText();
 		String expectedDiagramText = IOUtils.toString(
-				this.getClass().getClassLoader().getResource("0010_parameterized_aggregation_type.txt"), "utf-8");
-		assertNotNull(result);
-		assertNotNull(expectedDiagramText);
-		assertEquals(expectedDiagramText.replaceAll("\\s+", ""), result.replaceAll("\\s+", ""));
-	}
-
-	/**
-	 * Test custom classloader.
-	 *
-	 * @throws Exception the exception
-	 */
-	@Test
-	public void testClassloader() throws Exception {
-		String filename = "0008_classloader_test.txt";
-		URL testResourceURL = this.getClass().getClassLoader().getResource(filename);
-		String testResourceURLString = testResourceURL.toString();
-		String testClassPath = testResourceURLString.substring(0, testResourceURLString.length() - filename.length())
-				+ "../../src/test/classes/";
-		URL[] classesURLs = new URL[] { new URL(testClassPath) };
-		URLClassLoader classLoader = new URLClassLoader(classesURLs);
-		classLoader.loadClass("de.elnarion.maven.plugin.plantuml.generator.test.domain.ChildA");
-		List<String> scanpackages = new ArrayList<>();
-		scanpackages.add("de.elnarion.maven.plugin.plantuml.generator.test.domain");
-		List<String> hideClasses = new ArrayList<>();
-		PlantUMLClassDiagramGenerator generator = new PlantUMLClassDiagramGenerator(classLoader, scanpackages, null,
-				hideClasses, true, true);
-		String result = generator.generateDiagramText();
-		String expectedDiagramText = IOUtils.toString(this.getClass().getClassLoader().getResource(filename), "utf-8");
+				this.getClass().getClassLoader().getResource("0010_parameterized_aggregation_type.txt"), StandardCharsets.UTF_8);
 		assertNotNull(result);
 		assertNotNull(expectedDiagramText);
 		assertEquals(expectedDiagramText.replaceAll("\\s+", ""), result.replaceAll("\\s+", ""));
@@ -229,35 +249,15 @@ public class PlantUMLClassDiagramGeneratorTest {
 	 * @throws Exception the exception
 	 */
 	@Test
-	public void testJarPackage() throws Exception {
-		String filename = "0009_jar_test.txt";
-		List<String> scanpackages = new ArrayList<>();
-		scanpackages.add("org.apache.commons.io.monitor");
-		List<String> hideClasses = new ArrayList<>();
-		PlantUMLClassDiagramGenerator generator = new PlantUMLClassDiagramGenerator(this.getClass().getClassLoader(),
-				scanpackages, null, hideClasses, true, true);
-		String result = generator.generateDiagramText();
-		String expectedDiagramText = IOUtils.toString(this.getClass().getClassLoader().getResource(filename), "utf-8");
-		assertNotNull(result);
-		assertNotNull(expectedDiagramText);
-		assertEquals(expectedDiagramText.replaceAll("\\s+", ""), result.replaceAll("\\s+", ""));
-	}
-
-	/**
-	 * Test classes contained in a package in a jar.
-	 *
-	 * @throws Exception the exception
-	 */
-	@Test
-	public void testJarPackageWithBlacklist() throws Exception {
+	public void test0011JarPackageWithBlacklist() throws Exception {
 		String filename = "0011_jar_test_blacklist.txt";
-		List<String> scanpackages = new ArrayList<>();
-		scanpackages.add("org.apache.commons.io.monitor");
+		List<String> scanPackages = new ArrayList<>();
+		scanPackages.add("org.apache.commons.io.monitor");
 		List<String> hideClasses = new ArrayList<>();
-		PlantUMLClassDiagramGenerator generator = new PlantUMLClassDiagramGenerator(this.getClass().getClassLoader(),
-				scanpackages, ".*FileEn.*", hideClasses, true, true);
+		PlantUMLClassDiagramGenerator generator = new PlantUMLClassDiagramGenerator(classLoader,
+				scanPackages, ".*FileEn.*", hideClasses, true, true);
 		String result = generator.generateDiagramText();
-		String expectedDiagramText = IOUtils.toString(this.getClass().getClassLoader().getResource(filename), "utf-8");
+		String expectedDiagramText = IOUtils.toString(classLoader.getResource(filename), StandardCharsets.UTF_8);
 		assertNotNull(result);
 		assertNotNull(expectedDiagramText);
 		assertEquals(expectedDiagramText.replaceAll("\\s+", ""), result.replaceAll("\\s+", ""));
@@ -269,15 +269,13 @@ public class PlantUMLClassDiagramGeneratorTest {
 	 * @throws Exception the exception
 	 */
 	@Test
-	public void testJarPackageWithWithelist() throws Exception {
+	public void test0012JarPackageWithWhitelist() throws Exception {
 		String filename = "0012_jar_whitelist.txt";
-		List<String> scanpackages = new ArrayList<>();
-		scanpackages.add("org.apache.commons.io.monitor");
 		List<String> hideClasses = new ArrayList<>();
-		PlantUMLClassDiagramGenerator generator = new PlantUMLClassDiagramGenerator(this.getClass().getClassLoader(),
+		PlantUMLClassDiagramGenerator generator = new PlantUMLClassDiagramGenerator(classLoader,
 				".*FileAl.*", hideClasses, true, true, null);
 		String result = generator.generateDiagramText();
-		String expectedDiagramText = IOUtils.toString(this.getClass().getClassLoader().getResource(filename), "utf-8");
+		String expectedDiagramText = IOUtils.toString(classLoader.getResource(filename), StandardCharsets.UTF_8);
 		assertNotNull(result);
 		assertNotNull(expectedDiagramText);
 		assertEquals(expectedDiagramText.replaceAll("\\s+", ""), result.replaceAll("\\s+", ""));
@@ -286,47 +284,44 @@ public class PlantUMLClassDiagramGeneratorTest {
 	@Test
 	public void test0013MaxVisibilityFields() throws Exception {
 		String filename = "0013_max_visibility_fields_public.txt";
-		URL testResourceURL = this.getClass().getClassLoader().getResource(filename);
-		String testResourceURLString = testResourceURL.toString();
-		String testClassPath = testResourceURLString.substring(0, testResourceURLString.length() - filename.length())
-				+ "../../src/test/classes/";
-		URL[] classesURLs = new URL[] { new URL(testClassPath) };
-		URLClassLoader classLoader = new URLClassLoader(classesURLs);
-		classLoader.loadClass("de.elnarion.test.domain.t0013.Testclass");
-		List<String> scanpackages = new ArrayList<>();
-		scanpackages.add("de.elnarion.test.domain.t0013");
-		PlantUMLConfig config = new PlantUMLConfigBuilder(scanpackages).withClassLoader(classLoader)
+		List<String> scanPackages = new ArrayList<>();
+		scanPackages.add("de.elnarion.test.domain.t0013");
+		PlantUMLConfig config = new PlantUMLConfigBuilder(scanPackages)
+				.withClassLoader(classLoader)
 				.withMaximumFieldVisibility(VisibilityType.PUBLIC).build();
 		PlantUMLClassDiagramGenerator generator = new PlantUMLClassDiagramGenerator(config);
 		String result = generator.generateDiagramText();
-		String expectedDiagramText = IOUtils.toString(this.getClass().getClassLoader().getResource(filename), "utf-8");
+		String expectedDiagramText = IOUtils.toString(classLoader.getResource(filename), StandardCharsets.UTF_8);
 		assertNotNull(result);
 		assertNotNull(expectedDiagramText);
 		assertEquals(expectedDiagramText.replaceAll("\\s+", ""), result.replaceAll("\\s+", ""));
-		config = new PlantUMLConfigBuilder(scanpackages).withClassLoader(classLoader)
+		config = new PlantUMLConfigBuilder(scanPackages)
+				.withClassLoader(classLoader)
 				.withMaximumFieldVisibility(VisibilityType.PROTECTED).build();
 		generator = new PlantUMLClassDiagramGenerator(config);
 		result = generator.generateDiagramText();
 		filename = "0013_max_visibility_fields_protected.txt";
-		expectedDiagramText = IOUtils.toString(this.getClass().getClassLoader().getResource(filename), "utf-8");
+		expectedDiagramText = IOUtils.toString(classLoader.getResource(filename), StandardCharsets.UTF_8);
 		assertNotNull(result);
 		assertNotNull(expectedDiagramText);
 		assertEquals(expectedDiagramText.replaceAll("\\s+", ""), result.replaceAll("\\s+", ""));
-		config = new PlantUMLConfigBuilder(scanpackages).withClassLoader(classLoader)
+		config = new PlantUMLConfigBuilder(scanPackages)
+				.withClassLoader(classLoader)
 				.withMaximumFieldVisibility(VisibilityType.PACKAGE_PRIVATE).build();
 		generator = new PlantUMLClassDiagramGenerator(config);
 		result = generator.generateDiagramText();
 		filename = "0013_max_visibility_fields_package_private.txt";
-		expectedDiagramText = IOUtils.toString(this.getClass().getClassLoader().getResource(filename), "utf-8");
+		expectedDiagramText = IOUtils.toString(classLoader.getResource(filename), StandardCharsets.UTF_8);
 		assertNotNull(result);
 		assertNotNull(expectedDiagramText);
 		assertEquals(expectedDiagramText.replaceAll("\\s+", ""), result.replaceAll("\\s+", ""));
-		config = new PlantUMLConfigBuilder(scanpackages).withClassLoader(classLoader)
+		config = new PlantUMLConfigBuilder(scanPackages)
+				.withClassLoader(classLoader)
 				.withMaximumFieldVisibility(VisibilityType.PRIVATE).build();
 		generator = new PlantUMLClassDiagramGenerator(config);
 		result = generator.generateDiagramText();
 		filename = "0013_max_visibility_fields_private.txt";
-		expectedDiagramText = IOUtils.toString(this.getClass().getClassLoader().getResource(filename), "utf-8");
+		expectedDiagramText = IOUtils.toString(classLoader.getResource(filename), StandardCharsets.UTF_8);
 		assertNotNull(result);
 		assertNotNull(expectedDiagramText);
 		assertEquals(expectedDiagramText.replaceAll("\\s+", ""), result.replaceAll("\\s+", ""));
@@ -335,47 +330,45 @@ public class PlantUMLClassDiagramGeneratorTest {
 	@Test
 	public void test0014MaxVisibilityMethods() throws Exception {
 		String filename = "0014_max_visibility_methods_public.txt";
-		URL testResourceURL = this.getClass().getClassLoader().getResource(filename);
-		String testResourceURLString = testResourceURL.toString();
-		String testClassPath = testResourceURLString.substring(0, testResourceURLString.length() - filename.length())
-				+ "../../src/test/classes/";
-		URL[] classesURLs = new URL[] { new URL(testClassPath) };
-		URLClassLoader classLoader = new URLClassLoader(classesURLs);
 		classLoader.loadClass("de.elnarion.test.domain.t0014.Testclass");
-		List<String> scanpackages = new ArrayList<>();
-		scanpackages.add("de.elnarion.test.domain.t0014");
-		PlantUMLConfig config = new PlantUMLConfigBuilder(scanpackages).withClassLoader(classLoader)
+		List<String> scanPackages = new ArrayList<>();
+		scanPackages.add("de.elnarion.test.domain.t0014");
+		PlantUMLConfig config = new PlantUMLConfigBuilder(scanPackages)
+				.withClassLoader(classLoader)
 				.withMaximumMethodVisibility(VisibilityType.PUBLIC).build();
 		PlantUMLClassDiagramGenerator generator = new PlantUMLClassDiagramGenerator(config);
 		String result = generator.generateDiagramText();
-		String expectedDiagramText = IOUtils.toString(this.getClass().getClassLoader().getResource(filename), "utf-8");
+		String expectedDiagramText = IOUtils.toString(classLoader.getResource(filename), StandardCharsets.UTF_8);
 		assertNotNull(result);
 		assertNotNull(expectedDiagramText);
 		assertEquals(expectedDiagramText.replaceAll("\\s+", ""), result.replaceAll("\\s+", ""));
-		config = new PlantUMLConfigBuilder(scanpackages).withClassLoader(classLoader)
+		config = new PlantUMLConfigBuilder(scanPackages).
+				withClassLoader(classLoader)
 				.withMaximumMethodVisibility(VisibilityType.PROTECTED).build();
 		generator = new PlantUMLClassDiagramGenerator(config);
 		result = generator.generateDiagramText();
 		filename = "0014_max_visibility_methods_protected.txt";
-		expectedDiagramText = IOUtils.toString(this.getClass().getClassLoader().getResource(filename), "utf-8");
+		expectedDiagramText = IOUtils.toString(classLoader.getResource(filename), StandardCharsets.UTF_8);
 		assertNotNull(result);
 		assertNotNull(expectedDiagramText);
 		assertEquals(expectedDiagramText.replaceAll("\\s+", ""), result.replaceAll("\\s+", ""));
-		config = new PlantUMLConfigBuilder(scanpackages).withClassLoader(classLoader)
+		config = new PlantUMLConfigBuilder(scanPackages)
+				.withClassLoader(classLoader)
 				.withMaximumMethodVisibility(VisibilityType.PACKAGE_PRIVATE).build();
 		generator = new PlantUMLClassDiagramGenerator(config);
 		result = generator.generateDiagramText();
 		filename = "0014_max_visibility_methods_package_private.txt";
-		expectedDiagramText = IOUtils.toString(this.getClass().getClassLoader().getResource(filename), "utf-8");
+		expectedDiagramText = IOUtils.toString(classLoader.getResource(filename), StandardCharsets.UTF_8);
 		assertNotNull(result);
 		assertNotNull(expectedDiagramText);
 		assertEquals(expectedDiagramText.replaceAll("\\s+", ""), result.replaceAll("\\s+", ""));
-		config = new PlantUMLConfigBuilder(scanpackages).withClassLoader(classLoader)
+		config = new PlantUMLConfigBuilder(scanPackages)
+				.withClassLoader(classLoader)
 				.withMaximumMethodVisibility(VisibilityType.PRIVATE).build();
 		generator = new PlantUMLClassDiagramGenerator(config);
 		result = generator.generateDiagramText();
 		filename = "0014_max_visibility_methods_private.txt";
-		expectedDiagramText = IOUtils.toString(this.getClass().getClassLoader().getResource(filename), "utf-8");
+		expectedDiagramText = IOUtils.toString(classLoader.getResource(filename), StandardCharsets.UTF_8);
 		assertNotNull(result);
 		assertNotNull(expectedDiagramText);
 		assertEquals(expectedDiagramText.replaceAll("\\s+", ""), result.replaceAll("\\s+", ""));
@@ -384,21 +377,16 @@ public class PlantUMLClassDiagramGeneratorTest {
 	@Test
 	public void test0015RemoveMethods() throws Exception {
 		String filename = "0015_remove_methods.txt";
-		URL testResourceURL = this.getClass().getClassLoader().getResource(filename);
-		String testResourceURLString = testResourceURL.toString();
-		String testClassPath = testResourceURLString.substring(0, testResourceURLString.length() - filename.length())
-				+ "../../src/test/classes/";
-		URL[] classesURLs = new URL[] { new URL(testClassPath) };
-		URLClassLoader classLoader = new URLClassLoader(classesURLs);
 		classLoader.loadClass("de.elnarion.test.domain.t0015.Testclass1");
 		classLoader.loadClass("de.elnarion.test.domain.t0015.Testclass2");
-		List<String> scanpackages = new ArrayList<>();
-		scanpackages.add("de.elnarion.test.domain.t0015");
-		PlantUMLConfig config = new PlantUMLConfigBuilder(scanpackages).withClassLoader(classLoader)
+		List<String> scanPackages = new ArrayList<>();
+		scanPackages.add("de.elnarion.test.domain.t0015");
+		PlantUMLConfig config = new PlantUMLConfigBuilder(scanPackages)
+				.withClassLoader(classLoader)
 				.withRemoveMethods(true).build();
 		PlantUMLClassDiagramGenerator generator = new PlantUMLClassDiagramGenerator(config);
 		String result = generator.generateDiagramText();
-		String expectedDiagramText = IOUtils.toString(this.getClass().getClassLoader().getResource(filename), "utf-8");
+		String expectedDiagramText = IOUtils.toString(classLoader.getResource(filename), StandardCharsets.UTF_8);
 		assertNotNull(result);
 		assertNotNull(expectedDiagramText);
 		assertEquals(expectedDiagramText.replaceAll("\\s+", ""), result.replaceAll("\\s+", ""));
@@ -407,21 +395,16 @@ public class PlantUMLClassDiagramGeneratorTest {
 	@Test
 	public void test0016RemoveFields() throws Exception {
 		String filename = "0016_remove_fields.txt";
-		URL testResourceURL = this.getClass().getClassLoader().getResource(filename);
-		String testResourceURLString = testResourceURL.toString();
-		String testClassPath = testResourceURLString.substring(0, testResourceURLString.length() - filename.length())
-				+ "../../src/test/classes/";
-		URL[] classesURLs = new URL[] { new URL(testClassPath) };
-		URLClassLoader classLoader = new URLClassLoader(classesURLs);
 		classLoader.loadClass("de.elnarion.test.domain.t0016.Testclass1");
 		classLoader.loadClass("de.elnarion.test.domain.t0016.Testclass2");
-		List<String> scanpackages = new ArrayList<>();
-		scanpackages.add("de.elnarion.test.domain.t0016");
-		PlantUMLConfig config = new PlantUMLConfigBuilder(scanpackages).withClassLoader(classLoader)
+		List<String> scanPackages = new ArrayList<>();
+		scanPackages.add("de.elnarion.test.domain.t0016");
+		PlantUMLConfig config = new PlantUMLConfigBuilder(scanPackages)
+				.withClassLoader(classLoader)
 				.withRemoveFields(true).build();
 		PlantUMLClassDiagramGenerator generator = new PlantUMLClassDiagramGenerator(config);
 		String result = generator.generateDiagramText();
-		String expectedDiagramText = IOUtils.toString(this.getClass().getClassLoader().getResource(filename), "utf-8");
+		String expectedDiagramText = IOUtils.toString(classLoader.getResource(filename), StandardCharsets.UTF_8);
 		assertNotNull(result);
 		assertNotNull(expectedDiagramText);
 		assertEquals(expectedDiagramText.replaceAll("\\s+", ""), result.replaceAll("\\s+", ""));
@@ -430,20 +413,15 @@ public class PlantUMLClassDiagramGeneratorTest {
 	@Test
 	public void test0017BlacklistMethods() throws Exception {
 		String filename = "0017_blacklist_methods.txt";
-		URL testResourceURL = this.getClass().getClassLoader().getResource(filename);
-		String testResourceURLString = testResourceURL.toString();
-		String testClassPath = testResourceURLString.substring(0, testResourceURLString.length() - filename.length())
-				+ "../../src/test/classes/";
-		URL[] classesURLs = new URL[] { new URL(testClassPath) };
-		URLClassLoader classLoader = new URLClassLoader(classesURLs);
 		classLoader.loadClass("de.elnarion.test.domain.t0017.Testclass1");
-		List<String> scanpackages = new ArrayList<>();
-		scanpackages.add("de.elnarion.test.domain.t0017");
-		PlantUMLConfig config = new PlantUMLConfigBuilder(scanpackages).withClassLoader(classLoader)
+		List<String> scanPackages = new ArrayList<>();
+		scanPackages.add("de.elnarion.test.domain.t0017");
+		PlantUMLConfig config = new PlantUMLConfigBuilder(scanPackages)
+				.withClassLoader(classLoader)
 				.withMethodBlacklistRegexp(".*doSomething1.*").build();
 		PlantUMLClassDiagramGenerator generator = new PlantUMLClassDiagramGenerator(config);
 		String result = generator.generateDiagramText();
-		String expectedDiagramText = IOUtils.toString(this.getClass().getClassLoader().getResource(filename), "utf-8");
+		String expectedDiagramText = IOUtils.toString(classLoader.getResource(filename), StandardCharsets.UTF_8);
 		assertNotNull(result);
 		assertNotNull(expectedDiagramText);
 		assertEquals(expectedDiagramText.replaceAll("\\s+", ""), result.replaceAll("\\s+", ""));
@@ -452,20 +430,15 @@ public class PlantUMLClassDiagramGeneratorTest {
 	@Test
 	public void test0018BlacklistFields() throws Exception {
 		String filename = "0018_blacklist_fields.txt";
-		URL testResourceURL = this.getClass().getClassLoader().getResource(filename);
-		String testResourceURLString = testResourceURL.toString();
-		String testClassPath = testResourceURLString.substring(0, testResourceURLString.length() - filename.length())
-				+ "../../src/test/classes/";
-		URL[] classesURLs = new URL[] { new URL(testClassPath) };
-		URLClassLoader classLoader = new URLClassLoader(classesURLs);
 		classLoader.loadClass("de.elnarion.test.domain.t0018.Testclass1");
-		List<String> scanpackages = new ArrayList<>();
-		scanpackages.add("de.elnarion.test.domain.t0018");
-		PlantUMLConfig config = new PlantUMLConfigBuilder(scanpackages).withClassLoader(classLoader)
+		List<String> scanPackages = new ArrayList<>();
+		scanPackages.add("de.elnarion.test.domain.t0018");
+		PlantUMLConfig config = new PlantUMLConfigBuilder(scanPackages)
+				.withClassLoader(classLoader)
 				.withFieldBlacklistRegexp("test1").build();
 		PlantUMLClassDiagramGenerator generator = new PlantUMLClassDiagramGenerator(config);
 		String result = generator.generateDiagramText();
-		String expectedDiagramText = IOUtils.toString(this.getClass().getClassLoader().getResource(filename), "utf-8");
+		String expectedDiagramText = IOUtils.toString(classLoader.getResource(filename), StandardCharsets.UTF_8);
 		assertNotNull(result);
 		assertNotNull(expectedDiagramText);
 		assertEquals(expectedDiagramText.replaceAll("\\s+", ""), result.replaceAll("\\s+", ""));
@@ -474,20 +447,14 @@ public class PlantUMLClassDiagramGeneratorTest {
 	@Test
 	public void test0019IgnoreClassifierFields() throws Exception {
 		String filename = "0019_ignore_classifier_fields.txt";
-		URL testResourceURL = this.getClass().getClassLoader().getResource(filename);
-		String testResourceURLString = testResourceURL.toString();
-		String testClassPath = testResourceURLString.substring(0, testResourceURLString.length() - filename.length())
-				+ "../../src/test/classes/";
-		URL[] classesURLs = new URL[] { new URL(testClassPath) };
-		URLClassLoader classLoader = new URLClassLoader(classesURLs);
-		classLoader.loadClass("de.elnarion.test.domain.t0019.Testclass");
-		List<String> scanpackages = new ArrayList<>();
-		scanpackages.add("de.elnarion.test.domain.t0019");
-		PlantUMLConfig config = new PlantUMLConfigBuilder(scanpackages).withClassLoader(classLoader)
+		List<String> scanPackages = new ArrayList<>();
+		scanPackages.add("de.elnarion.test.domain.t0019");
+		PlantUMLConfig config = new PlantUMLConfigBuilder(scanPackages)
+				.withClassLoader(classLoader)
 				.addFieldClassifierToIgnore(ClassifierType.STATIC).build();
 		PlantUMLClassDiagramGenerator generator = new PlantUMLClassDiagramGenerator(config);
 		String result = generator.generateDiagramText();
-		String expectedDiagramText = IOUtils.toString(this.getClass().getClassLoader().getResource(filename), "utf-8");
+		String expectedDiagramText = IOUtils.toString(classLoader.getResource(filename), StandardCharsets.UTF_8);
 		assertNotNull(result);
 		assertNotNull(expectedDiagramText);
 		assertEquals(expectedDiagramText.replaceAll("\\s+", ""), result.replaceAll("\\s+", ""));
@@ -496,20 +463,15 @@ public class PlantUMLClassDiagramGeneratorTest {
 	@Test
 	public void test0020IgnoreClassifierMethods() throws Exception {
 		String filename = "0020_ignore_classifier_methods.txt";
-		URL testResourceURL = this.getClass().getClassLoader().getResource(filename);
-		String testResourceURLString = testResourceURL.toString();
-		String testClassPath = testResourceURLString.substring(0, testResourceURLString.length() - filename.length())
-				+ "../../src/test/classes/";
-		URL[] classesURLs = new URL[] { new URL(testClassPath) };
-		URLClassLoader classLoader = new URLClassLoader(classesURLs);
 		classLoader.loadClass("de.elnarion.test.domain.t0020.Testclass");
-		List<String> scanpackages = new ArrayList<>();
-		scanpackages.add("de.elnarion.test.domain.t0020");
-		PlantUMLConfig config = new PlantUMLConfigBuilder(scanpackages).withClassLoader(classLoader)
+		List<String> scanPackages = new ArrayList<>();
+		scanPackages.add("de.elnarion.test.domain.t0020");
+		PlantUMLConfig config = new PlantUMLConfigBuilder(scanPackages)
+				.withClassLoader(classLoader)
 				.addMethodClassifierToIgnore(ClassifierType.STATIC).build();
 		PlantUMLClassDiagramGenerator generator = new PlantUMLClassDiagramGenerator(config);
 		String result = generator.generateDiagramText();
-		String expectedDiagramText = IOUtils.toString(this.getClass().getClassLoader().getResource(filename), "utf-8");
+		String expectedDiagramText = IOUtils.toString(classLoader.getResource(filename), StandardCharsets.UTF_8);
 		assertNotNull(result);
 		assertNotNull(expectedDiagramText);
 		assertEquals(expectedDiagramText.replaceAll("\\s+", ""), result.replaceAll("\\s+", ""));
@@ -518,13 +480,14 @@ public class PlantUMLClassDiagramGeneratorTest {
 	@Test
 	public void test0021JPAAnnotations() throws Exception {
 		String filename = "0021_jpa_annotations.txt";
-		List<String> scanpackages = new ArrayList<>();
-		scanpackages.add("de.elnarion.test.domain.t0021");
-		PlantUMLConfig config = new PlantUMLConfigBuilder(scanpackages)
-				.withClassLoader(this.getClass().getClassLoader()).withJPAAnnotations(true).build();
+		List<String> scanPackages = new ArrayList<>();
+		scanPackages.add("de.elnarion.test.domain.t0021");
+		PlantUMLConfig config = new PlantUMLConfigBuilder(scanPackages)
+				.withClassLoader(classLoader)
+				.withJPAAnnotations(true).build();
 		PlantUMLClassDiagramGenerator generator = new PlantUMLClassDiagramGenerator(config);
 		String result = generator.generateDiagramText();
-		String expectedDiagramText = IOUtils.toString(this.getClass().getClassLoader().getResource(filename), "utf-8");
+		String expectedDiagramText = IOUtils.toString(classLoader.getResource(filename), StandardCharsets.UTF_8);
 		assertNotNull(result);
 		System.out.println(result);
 		assertNotNull(expectedDiagramText);
@@ -534,15 +497,18 @@ public class PlantUMLClassDiagramGeneratorTest {
 	@Test
 	public void test0022PrivateFinalFields() throws Exception {
 		String filename = "0022_private_final_field.txt";
-		List<String> scanpackages = new ArrayList<>();
-		scanpackages.add("de.elnarion.test.domain.t0022");
-		PlantUMLConfig config = new PlantUMLConfigBuilder(".*\\$.*|com.xx.common.converter.BeanConverter|.*\\.metamodel\\..*",scanpackages)
-				.withClassLoader(this.getClass().getClassLoader()).withHideMethods(false).withHideFieldsParameter(false)
-				.withMaximumFieldVisibility(VisibilityType.PRIVATE).withMaximumMethodVisibility(VisibilityType.PUBLIC)
+		List<String> scanPackages = new ArrayList<>();
+		scanPackages.add("de.elnarion.test.domain.t0022");
+		PlantUMLConfig config = new PlantUMLConfigBuilder(".*\\$.*|com.xx.common.converter.BeanConverter|.*\\.metamodel\\..*",scanPackages)
+				.withClassLoader(classLoader)
+				.withHideMethods(false)
+				.withHideFieldsParameter(false)
+				.withMaximumFieldVisibility(VisibilityType.PRIVATE)
+				.withMaximumMethodVisibility(VisibilityType.PUBLIC)
 				.withMethodBlacklistRegexp("(hashCode|equals)").build();
 		PlantUMLClassDiagramGenerator generator = new PlantUMLClassDiagramGenerator(config);
 		String result = generator.generateDiagramText();
-		String expectedDiagramText = IOUtils.toString(this.getClass().getClassLoader().getResource(filename), "utf-8");
+		String expectedDiagramText = IOUtils.toString(classLoader.getResource(filename), StandardCharsets.UTF_8);
 		assertNotNull(result);
 		System.out.println(result);
 		assertNotNull(expectedDiagramText);


### PR DESCRIPTION
Fixes #18

What I did:
- extract common code fragments
- use `StandardCharsets.UTF_8` instead of `"utf-8"`
- always use normal ClassLoader, unless in the specific test for that
- normalize test method naming