### PR TITLE
Add Smetana support

### DIFF
--- a/plantuml-generator-maven-plugin/src/it/classdiagram/0025-use-smetana-it/invoker.properties
+++ b/plantuml-generator-maven-plugin/src/it/classdiagram/0025-use-smetana-it/invoker.properties
@@ -1,0 +1,1 @@
+# no invoker property necessary

--- a/plantuml-generator-maven-plugin/src/it/classdiagram/0025-use-smetana-it/pom.xml
+++ b/plantuml-generator-maven-plugin/src/it/classdiagram/0025-use-smetana-it/pom.xml
@@ -1,0 +1,57 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>de.elnarion.maven.plugin.it</groupId>
+	<artifactId>class-0024-use-short-classnames-in-fields-and-methods-it</artifactId>
+	<version>1.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+	<!-- tag::dependencies[] -->
+	<dependencies>
+		<dependency>
+			<groupId>de.elnarion.util</groupId>
+			<artifactId>plantuml-generator-util</artifactId>
+			<version>@project.version@</version>
+			<classifier>tests</classifier>
+			<type>test-jar</type>
+		</dependency>
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.13.0</version>
+		</dependency>
+		<dependency>
+			<groupId>javax.persistence</groupId>
+			<artifactId>javax.persistence-api</artifactId>
+			<version>2.2</version>
+		</dependency>
+	</dependencies>
+	<!-- end::dependencies[] -->
+	<build>
+		<plugins>
+			<!-- tag::mvn[] -->
+			<plugin>
+				<artifactId>plantuml-generator-maven-plugin</artifactId>
+				<groupId>de.elnarion.maven</groupId>
+				<version>@project.version@</version>
+				<executions>
+					<execution>
+						<id>generate-simple-diagram</id>
+						<goals>
+							<goal>generate</goal>
+						</goals>
+						<phase>generate-test-sources</phase>
+						<configuration>
+							<useSmetana>true</useSmetana>
+							<outputFilename>testdiagram1.txt</outputFilename>
+							<scanPackages>
+								<scanPackage>de.elnarion.test.domain.t0027</scanPackage>
+							</scanPackages>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<!-- end::mvn[] -->
+		</plugins>
+	</build>
+</project>

--- a/plantuml-generator-maven-plugin/src/it/classdiagram/0025-use-smetana-it/verify.groovy
+++ b/plantuml-generator-maven-plugin/src/it/classdiagram/0025-use-smetana-it/verify.groovy
@@ -1,0 +1,11 @@
+File buildLog = new File( basedir, 'build.log' )
+assert buildLog.exists()
+assert buildLog.text.contains( "[INFO] Starting plantuml generation" )
+
+File buildDiagram = new File( basedir.absolutePath+'/target/generated-docs/testdiagram1.txt' )
+File testDiagram = new File( basedir.absolutePath+'/../../../../../plantuml-generator-util/src/test/resources/class/0027_use_smetana.txt' )
+assert buildDiagram.exists()
+assert testDiagram.exists()
+String buildDiagramText = buildDiagram.text 
+String testDiagramText =  testDiagram.text
+assert testDiagramText.replaceAll("\\s+", "").equals(buildDiagramText.replaceAll("\\s+", "")) 

--- a/plantuml-generator-maven-plugin/src/main/java/de/elnarion/maven/plugin/plantuml/generator/PlantUMLGeneratorMojo.java
+++ b/plantuml-generator-maven-plugin/src/main/java/de/elnarion/maven/plugin/plantuml/generator/PlantUMLGeneratorMojo.java
@@ -20,6 +20,9 @@ import java.util.List;
 @Mojo(name = "generate", defaultPhase = LifecyclePhase.GENERATE_SOURCES, threadSafe = true, requiresDependencyResolution = ResolutionScope.COMPILE, requiresProject = true)
 public class PlantUMLGeneratorMojo extends AbstractPlantUMLGeneratorMojo {
 
+	/** The use Smetana renderer. */
+	@Parameter(property = PREFIX + "useSmetana", defaultValue = "false", required = false)
+	private boolean useSmetana = false;
 	/** The remove methods. */
 	@Parameter(property = PREFIX + "fieldBlacklistRegexp", defaultValue = "", required = false)
 	private final String fieldBlacklistRegexp = null;
@@ -96,6 +99,7 @@ public class PlantUMLGeneratorMojo extends AbstractPlantUMLGeneratorMojo {
 				configBuilder = new PlantUMLClassDiagramConfigBuilder(scanPackages, whitelistRegexp);
 			}
 			configBuilder.withClassLoader(loader).withHideClasses(hideClasses).withHideFieldsParameter(hideFields)
+					.withUseSmetana(useSmetana)
 					.withHideMethods(hideMethods).addFieldClassifiersToIgnore(fieldClassifierListToIgnore)
 					.addMethodClassifiersToIgnore(methodClassifierListToIgnore).withRemoveFields(removeFields)
 					.withRemoveMethods(removeMethods).withFieldBlacklistRegexp(fieldBlacklistRegexp)
@@ -111,6 +115,24 @@ public class PlantUMLGeneratorMojo extends AbstractPlantUMLGeneratorMojo {
 			getLog().error("Exception:" + e.getMessage());
 			getLog().error(e);
 		}
+	}
+
+	/**
+	 * Checks if Smetana is enabled.
+	 *
+	 * @return true, enabled.
+	 */
+	public boolean isUseSmetana() {
+		return useSmetana;
+	}
+
+	/**
+	 * Sets the Smetana.
+	 *
+	 * @param useSmetana set use Smetana
+	 */
+	public void setUseSmetana(boolean useSmetana) {
+		this.useSmetana = useSmetana;
 	}
 
 	/**

--- a/plantuml-generator-util/src/main/java/de/elnarion/util/plantuml/generator/classdiagram/config/PlantUMLClassDiagramConfig.java
+++ b/plantuml-generator-util/src/main/java/de/elnarion/util/plantuml/generator/classdiagram/config/PlantUMLClassDiagramConfig.java
@@ -14,6 +14,8 @@ public class PlantUMLClassDiagramConfig {
 	private final List<ClassifierType> methodClassifierToIgnore = new ArrayList<>();
 	/** The additional plant uml configs. */
 	private final List<String> additionalPlantUmlConfigs = new ArrayList<>();
+	/** The use plantuml smetana renderer in favor of GraphViz. */
+	private boolean useSmetana = false;
 	/** The destination classloader. */
 	private ClassLoader destinationClassloader = this.getClass().getClassLoader();
 	/** The scan packages. */
@@ -283,6 +285,23 @@ public class PlantUMLClassDiagramConfig {
 	 */
 	public List<String> getAdditionalPlantUmlConfigs() {
 		return additionalPlantUmlConfigs;
+	}
+
+	/**
+	 * Enables generating uml files enabling to use internal Smetana renderer in favor
+	 * of GraphViz <a href="https://plantuml.com/smetana02">Smetana</a>.
+	 */
+	public void setUseSmetana(boolean useSmetana) {
+		this.useSmetana = useSmetana;
+	}
+
+	/**
+	 * Checks if generating uml files using Smetana renderer enabled.
+	 *
+	 * @return true, if Smetana is enabled
+	 */
+	public boolean isUseSmetana() {
+		return useSmetana;
 	}
 
 	/**

--- a/plantuml-generator-util/src/main/java/de/elnarion/util/plantuml/generator/classdiagram/config/PlantUMLClassDiagramConfigBuilder.java
+++ b/plantuml-generator-util/src/main/java/de/elnarion/util/plantuml/generator/classdiagram/config/PlantUMLClassDiagramConfigBuilder.java
@@ -52,6 +52,17 @@ public class PlantUMLClassDiagramConfigBuilder {
 	}
 
 	/**
+	 * With remove fields.
+	 *
+	 * @param paramRemoveFields the param remove fields
+	 * @return PlantUMLConfigBuilder
+	 */
+	public PlantUMLClassDiagramConfigBuilder withUseSmetana(boolean paramRemoveFields) {
+		plantUMLConfig.setUseSmetana(paramRemoveFields);
+		return this;
+	}
+
+	/**
 	 * With class loader.
 	 *
 	 * @param paramDestinationClassLoader the param destination class loader

--- a/plantuml-generator-util/src/main/java/de/elnarion/util/plantuml/generator/classdiagram/internal/PlantUMLClassDiagramTextBuilder.java
+++ b/plantuml-generator-util/src/main/java/de/elnarion/util/plantuml/generator/classdiagram/internal/PlantUMLClassDiagramTextBuilder.java
@@ -79,6 +79,9 @@ public class PlantUMLClassDiagramTextBuilder {
 	 */
 	private void startUMLDiagram(final StringBuilder builder) {
 		builder.append("@startuml");
+		if(plantUMLConfig.isUseSmetana()) {
+			builder.append("!pragma layout smetana");
+		}
 	}
 
 	/**

--- a/plantuml-generator-util/src/test/java/de/elnarion/test/domain/t0027/TestClass.java
+++ b/plantuml-generator-util/src/test/java/de/elnarion/test/domain/t0027/TestClass.java
@@ -1,0 +1,10 @@
+package de.elnarion.test.domain.t0027;
+
+/**
+ * The Class TestFieldClass.
+ */
+public class TestClass {
+
+	private String testString;
+
+}

--- a/plantuml-generator-util/src/test/java/de/elnarion/util/plantuml/generator/classdiagram/PlantUMLClassDiagramGeneratorTest.java
+++ b/plantuml-generator-util/src/test/java/de/elnarion/util/plantuml/generator/classdiagram/PlantUMLClassDiagramGeneratorTest.java
@@ -727,4 +727,26 @@ class PlantUMLClassDiagramGeneratorTest {
         // end::aggregaterelationships[]
     }
 
+    /**
+     * Test generate diagram with different aggregate relationships
+     *
+     * @throws IOException Signals that an I/O exception has occurred.
+     */
+    @Test
+    void test0027UseSmetana() throws IOException {
+        // tag::usesmetana[]
+        List<String> scanPackages = new ArrayList<>();
+        scanPackages.add("de.elnarion.test.domain.t0027");
+        PlantUMLClassDiagramConfig config = new PlantUMLClassDiagramConfigBuilder(scanPackages)
+                .withUseSmetana(true).build();
+        PlantUMLClassDiagramGenerator generator = new PlantUMLClassDiagramGenerator(config);
+        String result = generator.generateDiagramText();
+        String expectedDiagramText = IOUtils.toString(
+                Objects.requireNonNull(classLoader.getResource("class/0027_use_smetana.txt")), StandardCharsets.UTF_8);
+        assertNotNull(result);
+        assertNotNull(expectedDiagramText);
+        assertEquals(expectedDiagramText.replaceAll("\\s+", ""), result.replaceAll("\\s+", ""));
+        // end::usesmetana[]
+    }
+
 }

--- a/plantuml-generator-util/src/test/resources/class/0027_use_smetana.txt
+++ b/plantuml-generator-util/src/test/resources/class/0027_use_smetana.txt
@@ -1,0 +1,8 @@
+@startuml
+!pragma layout smetana
+
+class de.elnarion.test.domain.t0027.TestClass {
+    {field} -testString : String
+}
+
+@enduml


### PR DESCRIPTION
Allows enabling [Smetana](https://plantuml.com/smetana02)  renderer in PlantUML (fixes https://github.com/devlauer/plantuml-generator/issues/100).

Example config:
```                        
<configuration>
   <useSmetana>true</useSmetana>
</configuration>
```