### PR TITLE
Add line separator for '!pragma layout smetana'

### DIFF
--- a/plantuml-generator-util/src/main/java/de/elnarion/util/plantuml/generator/classdiagram/internal/PlantUMLClassDiagramTextBuilder.java
+++ b/plantuml-generator-util/src/main/java/de/elnarion/util/plantuml/generator/classdiagram/internal/PlantUMLClassDiagramTextBuilder.java
@@ -80,6 +80,7 @@ public class PlantUMLClassDiagramTextBuilder {
 	private void startUMLDiagram(final StringBuilder builder) {
 		builder.append("@startuml");
 		if(plantUMLConfig.isUseSmetana()) {
+			builder.append(System.lineSeparator());
 			builder.append("!pragma layout smetana");
 		}
 	}


### PR DESCRIPTION
Fixes a bug, where '!pragma layout smetana' is placed next to @startuml (fixes https://github.com/devlauer/plantuml-generator/issues/100).

Resulting in PlantUML parser failing in enabling Smetana renderer.

Bug:
`@startuml!pragma layout smetana`

Fix:
```
@startuml
!pragma layout smetana
```


