### PR TITLE
Fix jakarta jpa information not fully present on diagrams

### DIFF
--- a/plantuml-generator-maven-plugin/src/it/classdiagram/0027-add-jpa-jakarta-annotations-it/.gitignore
+++ b/plantuml-generator-maven-plugin/src/it/classdiagram/0027-add-jpa-jakarta-annotations-it/.gitignore
@@ -1,0 +1,4 @@
+/.classpath
+/.project
+/.settings/
+/target/

--- a/plantuml-generator-maven-plugin/src/it/classdiagram/0027-add-jpa-jakarta-annotations-it/invoker.properties
+++ b/plantuml-generator-maven-plugin/src/it/classdiagram/0027-add-jpa-jakarta-annotations-it/invoker.properties
@@ -1,0 +1,1 @@
+# no invoker property necessary

--- a/plantuml-generator-maven-plugin/src/it/classdiagram/0027-add-jpa-jakarta-annotations-it/pom.xml
+++ b/plantuml-generator-maven-plugin/src/it/classdiagram/0027-add-jpa-jakarta-annotations-it/pom.xml
@@ -1,0 +1,67 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>de.elnarion.maven.plugin.it</groupId>
+	<artifactId>class-0027-add-jpa-jakarta-annotations-it</artifactId>
+	<version>1.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+
+	<!-- tag::dependencies[] -->
+	<dependencies>
+		<dependency>
+			<groupId>de.elnarion.util</groupId>
+			<artifactId>plantuml-generator-util</artifactId>
+			<version>@project.version@</version>
+			<classifier>tests</classifier>
+			<type>test-jar</type>
+		</dependency>
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.16.1</version>
+		</dependency>
+		<dependency>
+			<groupId>jakarta.persistence</groupId>
+			<artifactId>jakarta.persistence-api</artifactId>
+			<version>3.2.0</version>
+		</dependency>
+	</dependencies>
+	<!-- end::dependencies[] -->
+	<build>
+		<plugins>
+			<!-- tag::mvn[] -->
+			<plugin>
+				<artifactId>plantuml-generator-maven-plugin</artifactId>
+				<groupId>de.elnarion.maven</groupId>
+				<version>@project.version@</version>
+				<executions>
+					<execution>
+						<id>generate-simple-diagram</id>
+						<goals>
+							<goal>generate</goal>
+						</goals>
+						<phase>generate-test-sources</phase>
+						<configuration>
+							<outputFilename>testdiagram1.txt</outputFilename>
+							<scanPackages>
+								<scanPackage>de.elnarion.test.domain.t0021jakarta</scanPackage>
+							</scanPackages>
+							<addJPAAnnotations>true</addJPAAnnotations>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<!-- end::mvn[] -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<release>17</release>
+					<debug>true</debug>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/plantuml-generator-maven-plugin/src/it/classdiagram/0027-add-jpa-jakarta-annotations-it/verify.groovy
+++ b/plantuml-generator-maven-plugin/src/it/classdiagram/0027-add-jpa-jakarta-annotations-it/verify.groovy
@@ -1,0 +1,11 @@
+File buildLog = new File( basedir, 'build.log' )
+assert buildLog.exists()
+assert buildLog.text.contains( "[INFO] Starting plantuml generation" )
+
+File buildDiagram = new File( basedir.absolutePath+'/target/generated-docs/testdiagram1.txt' )
+File testDiagram = new File( basedir.absolutePath+'/../../../../../plantuml-generator-util/src/test/resources/class/0021_jpa_annotations_jakarta.txt' )
+assert buildDiagram.exists()
+assert testDiagram.exists()
+String buildDiagramText = buildDiagram.text 
+String testDiagramText =  testDiagram.text
+assert testDiagramText.replaceAll("\\s+", "").equals(buildDiagramText.replaceAll("\\s+", "")) 

--- a/plantuml-generator-util/src/main/java/de/elnarion/util/plantuml/generator/classdiagram/internal/JPAAnalyzerHelper.java
+++ b/plantuml-generator-util/src/main/java/de/elnarion/util/plantuml/generator/classdiagram/internal/JPAAnalyzerHelper.java
@@ -143,7 +143,11 @@ class JPAAnalyzerHelper {
 						"javax.persistence.Table", "Table");
 				addStereoTypesForAnnotationClass(paramClassObject, stereotypes, destinationClassloader,
 						"javax.persistence.MappedSuperclass", "MappedSuperclass");
+			} catch (ClassNotFoundException | SecurityException | IllegalArgumentException e) {
+				// ignore all exceptions
+			}
 
+			try {
 				// jakarta.persistance
 				addStereoTypesForAnnotationClass(paramClassObject, stereotypes, destinationClassloader,
 						"jakarta.persistence.Entity", "Entity");


### PR DESCRIPTION
Fix a bug where the JPA Helper silently fail to add the jakarta JPA annotation, by choking on unkown javax annotation

Added jakarta JPA Annotation test for the maven plugin.